### PR TITLE
add: CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - run: rustup update -no-self-update
+      - run: rustup update --no-self-update
       - run: cargo clippy
       - run: cargo fmt --check
       - run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update -no-self-update
+      - run: cargo clippy
+      - run: cargo fmt --check
+      - run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: Build
 
 on:
   push:
+    branches: [custom]
   pull_request:
+    branches: [custom]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,4 +36,8 @@ pub enum Error {
 
     #[error("Invalid path")]
     InvalidPath,
+
+    #[error("Cannot set  wallpaper mode3 on MacOS")]
+    #[cfg(target_os = "macos")]
+    MacOsUnsupportedMode,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,11 @@
 //! * i3 (set only, requires feh)
 //!
 //! # Example
-//! ```
-//!println!("{:?}", wallpaper::get());
-//!wallpaper::set_from_path("/usr/share/backgrounds/gnome/adwaita-day.png").unwrap();
-//!wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
-//!println!("{:?}", wallpaper::get());
+//! ```no_run
+//! println!("{:?}", wallpaper::get());
+//! wallpaper::set_from_path("/usr/share/backgrounds/gnome/adwaita-day.png").unwrap();
+//! wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
+//! println!("{:?}", wallpaper::get());
 //! ```
 
 mod error;

--- a/src/linux/gnome.rs
+++ b/src/linux/gnome.rs
@@ -33,7 +33,7 @@ where
     )
     // Ignore the result because in Gnome < 42 the cmd could fail since
     // key "picture-uri-dark" does not exists
-    .or_else(|_| res)
+    .or(res)
 }
 
 pub fn set_mode(mode: Mode) -> Result<()> {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -81,7 +81,7 @@ where
         ),
         _ => {
             if let Ok(mut child) = Command::new("swaybg")
-                .args(&["-i", path.as_ref().to_str().ok_or(Error::InvalidPath)?])
+                .args(["-i", path.as_ref().to_str().ok_or(Error::InvalidPath)?])
                 .spawn()
             {
                 child.stdout = None;

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,6 @@
-use crate::{get_stdout, run, Mode, Result};
+use std::path::Path;
+
+use crate::{error::Error, get_stdout, run, Mode, Result};
 
 #[cfg(feature = "from_url")]
 use crate::download_image;
@@ -15,18 +17,16 @@ pub fn get() -> Result<String> {
 }
 
 // Sets the wallpaper from a file.
-pub fn set_from_path<P>(path: P) -> Result<()>
-where
-    P: AsRef<Path> + std::fmt::Display,
-{
+pub fn set_from_path(path: &str) -> Result<()> {
     run(
         "osascript",
         &[
             "-e",
-            &format!(
+            format!(
                 r#"tell application "System Events" to tell every desktop to set picture to {}"#,
                 enquote::enquote('"', path),
-            ),
+            )
+            .as_str(),
         ],
     )
 }
@@ -40,5 +40,5 @@ pub fn set_from_url(url: &str) -> Result<()> {
 
 /// No-op. Unable to change with AppleScript.
 pub fn set_mode(_: Mode) -> Result<()> {
-    Err("unsupported on macos".into())
+    Err(Error::MacOsUnsupportedMode)
 }


### PR DESCRIPTION
executes
* clippy (linter)
* fmt (formatter)
* doctests (compile only)

uses Windows, MacOS and Linux CI runners from GitHub.

---
also addressed compilation problems with code specific to MacOS and Linux (per `clippy` output in CI).